### PR TITLE
Add support for Cyanogenmod recorder file types

### DIFF
--- a/audio-notes-mode.el
+++ b/audio-notes-mode.el
@@ -128,7 +128,7 @@ when you activate `audio-notes-mode'."
   :type '(choice string nil)
   :group 'audio-notes-mode)
 
-(defcustom anm/file-regexp "^[^\\.].*\.\\(mp[34]\\|wav\\|3ga\\)$"
+(defcustom anm/file-regexp "^[^\\.].*\.\\(mp[34]\\|wav\\|3ga\\|3gpp\\)$"
      "Regexp which filenames must match to be managed by OAN.
 
 Default is to play only mp4, mp3, wav and 3ga, and to exclude hidden files."


### PR DESCRIPTION
The recorder that comes with Cyanogenmod by default uses the file type 3gpp. It worked out of the box for me.
