### PR TITLE
adds m4a support

### DIFF
--- a/audio-notes-mode.el
+++ b/audio-notes-mode.el
@@ -128,7 +128,7 @@ when you activate `audio-notes-mode'."
   :type '(choice string nil)
   :group 'audio-notes-mode)
 
-(defcustom anm/file-regexp "^[^\\.].*\.\\(mp[34]\\|wav\\|3ga\\|3gpp\\)$"
+(defcustom anm/file-regexp "^[^\\.].*\.\\(mp[34]\\|wav\\|3ga\\|3gpp\\|m4a\\)$"
      "Regexp which filenames must match to be managed by OAN.
 
 Default is to play only mp4, mp3, wav and 3ga, and to exclude hidden files."


### PR DESCRIPTION
The iOS app 'Audio Memos - The Voice Recorder' uses m4a. With this app and audio-notes-mode it is possible to capture audio notes using an apple watch and listen to them in emacs.